### PR TITLE
Otimizar layout do painel

### DIFF
--- a/game/js/CDicesAnim.js
+++ b/game/js/CDicesAnim.js
@@ -39,8 +39,8 @@ function CDicesAnim(iX,iY){
         _aDicesAnimSprites = new Array();
         for(var i=0;i<NUM_DICE_ROLLING_FRAMES;i++){
             var oImage = createBitmap(s_oSpriteLibrary.getSprite('launch_dices_'+i)); 
-            oImage.x = 162;
-            oImage.y = 150;
+            oImage.x = 200;  // Mais centralizado
+            oImage.y = 120;  // Movido um pouco para cima
             oImage.visible = false;
             _oContainer.addChild(oImage);
             _aDicesAnimSprites.push(oImage);
@@ -63,8 +63,8 @@ function CDicesAnim(iX,iY){
         _oDiceASprite = createSprite(oSpriteSheet,"anim_1",80,34);
         _oDiceASprite.stop();
         _oDiceASprite.visible = false;
-        _oDiceASprite.x = 332;
-        _oDiceASprite.y = 206;
+        _oDiceASprite.x = 370;  // Ajustado
+        _oDiceASprite.y = 180;  // Ajustado
         _oContainer.addChild(_oDiceASprite);
         
         var oData = {   
@@ -81,12 +81,12 @@ function CDicesAnim(iX,iY){
         _oDiceBSprite = createSprite(oSpriteSheet,"anim_1",102,65);
         _oDiceBSprite.stop();
         _oDiceBSprite.visible = false;
-        _oDiceBSprite.x = 239;
-        _oDiceBSprite.y = 240;
+        _oDiceBSprite.x = 280;  // Ajustado
+        _oDiceBSprite.y = 220;  // Ajustado
         _oContainer.addChild(_oDiceBSprite);
         _oDiceBSprite.addEventListener("animationend", _oThis._onDiceBAnimEnded);
         
-        _oDiceTopDownView = new CDicesTopDownView(584,20,_oContainer);
+        _oDiceTopDownView = new CDicesTopDownView(550,30,_oContainer);  // Mais centralizado
     };
     
     this.unload =  function(){

--- a/game/js/CInterface.js
+++ b/game/js/CInterface.js
@@ -26,12 +26,12 @@ function CInterface(){
     this._init = function(){
         
         var oMoneyBg = createBitmap(s_oSpriteLibrary.getSprite('but_bg'));
-        oMoneyBg.x = 251;
-        oMoneyBg.y = 603;
+        oMoneyBg.x = 180;  // Movido mais para a esquerda
+        oMoneyBg.y = 680;  // Movido para baixo para dar mais espaço à mesa
         s_oStage.addChild(oMoneyBg);
         
         var oMoneyText = new CTLText(s_oStage, 
-                    260, 616, 140, 16, 
+                    189, 693, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     TEXT_MONEY,
@@ -41,7 +41,7 @@ function CInterface(){
 
         
         _oMoneyAmountText = new CTLText(s_oStage, 
-                    260, 636, 140, 16, 
+                    189, 713, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     " ",
@@ -50,12 +50,12 @@ function CInterface(){
 
         
         var oCurBetBg = createBitmap(s_oSpriteLibrary.getSprite('but_bg'));
-        oCurBetBg.x = 410;
-        oCurBetBg.y = 603;
+        oCurBetBg.x = 340;  // Movido mais para a esquerda
+        oCurBetBg.y = 680;  // Movido para baixo
         s_oStage.addChild(oCurBetBg);
         
         var oCurBetText = new CTLText(s_oStage, 
-                    419, 616, 140, 16, 
+                    349, 693, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     TEXT_CUR_BET,
@@ -64,7 +64,7 @@ function CInterface(){
                     
         
         _oBetAmountText = new CTLText(s_oStage, 
-                    419, 636, 140, 16, 
+                    349, 713, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     " ",
@@ -74,42 +74,42 @@ function CInterface(){
 
         
         _oDisplayBg = createBitmap(s_oSpriteLibrary.getSprite('but_bets'));
-        _oDisplayBg.x = 575;
-        _oDisplayBg.y = 610;
+        _oDisplayBg.x = 500;  // Movido mais para a esquerda
+        _oDisplayBg.y = 680;  // Movido para baixo
         s_oStage.addChild(_oDisplayBg);
 
         _oMsgTitle = new CTLText(s_oStage, 
                     _oDisplayBg.x+4, _oDisplayBg.y +4, 140, 40, 
-                    16, "center", "#fff", FONT1, 1.2,
+                    14, "center", "#fff", FONT1, 1.2,  // Fonte um pouco menor
                     0, 0,
                     TEXT_MIN_BET+": "+MIN_BET+"\n"+TEXT_MAX_BET+": "+MAX_BET,
                     true, true, true,
                     false );
 
         
-        // INFORMAÇÕES DA SALA - MOVIDO PARA O ESPAÇO VERDE DA MESA
+        // INFORMAÇÕES DA SALA - POSICIONADO NO ESPAÇO SUPERIOR CENTRAL
         var oRoomInfoBg = createBitmap(s_oSpriteLibrary.getSprite('display_bg'));
-        oRoomInfoBg.x = 450; // Posição no espaço verde da mesa
-        oRoomInfoBg.y = 50;  // Parte superior da mesa
+        oRoomInfoBg.x = 320; // Bem centralizado
+        oRoomInfoBg.y = 20;  // Parte superior da mesa
         s_oStage.addChild(oRoomInfoBg);
         
         _oRoomInfoText = new CTLText(s_oStage, 
                     oRoomInfoBg.x+114, oRoomInfoBg.y + 13, 130, 80, 
-                    16, "center", "#fff", FONT1, 1,
+                    14, "center", "#fff", FONT1, 1,  // Fonte um pouco menor
                     0, 0,
                     "SALA: " + s_oRoomConfig.getRoomName("principal") + "\nJOGADORES: 1/" + s_oRoomConfig.getRoomMaxPlayers("principal") + "\nAPOSTA MIN: " + s_oRoomConfig.getRoomMinBet("principal") + "\nAPOSTA MAX: Sem limite",
                     true, true, true,
                     false );
 
-        // HELP TEXT - MANTIDO NO CANTO DIREITO MAS AJUSTADO
+        // HELP TEXT - POSICIONADO AO LADO DAS INFORMAÇÕES DA SALA
         var oHelpBg = createBitmap(s_oSpriteLibrary.getSprite('display_bg'));
-        oHelpBg.x = 880;
-        oHelpBg.y = 210;
+        oHelpBg.x = 600;  // Lado direito das informações da sala
+        oHelpBg.y = 20;   // Mesma altura das informações da sala
         s_oStage.addChild(oHelpBg);
         
         _oHelpText =  new CTLText(s_oStage, 
                     oHelpBg.x+114, oHelpBg.y + 13, 130, 80, 
-                    20, "center", "#ffde00", FONT2, 1,
+                    18, "center", "#ffde00", FONT2, 1,  // Fonte um pouco menor
                     0, 0,
                     TEXT_WAITING_BET,
                     true, true, true,
@@ -118,11 +118,11 @@ function CInterface(){
         
         _szLastMsgHelp = TEXT_WAITING_BET;
 
-        _oRollBut = new CTextButton(1030,162,s_oSpriteLibrary.getSprite('roll_but'),"  "+TEXT_ROLL,FONT1,"#fff",22,"right",s_oStage);
+        _oRollBut = new CTextButton(880,20,s_oSpriteLibrary.getSprite('roll_but'),"  "+TEXT_ROLL,FONT1,"#fff",22,"right",s_oStage);  // Alinhado com outros elementos superiores
         _oRollBut.disable();
         _oRollBut.addEventListener(ON_MOUSE_UP, this._onRoll, this);
       
-        _oClearAllBet = new CGfxButton(764,636,s_oSpriteLibrary.getSprite('but_clear_all'),s_oStage);
+        _oClearAllBet = new CGfxButton(680,680,s_oSpriteLibrary.getSprite('but_clear_all'),s_oStage);  // Movido para baixo junto com outros controles
         _oClearAllBet.addEventListener(ON_MOUSE_UP, this._onClearAllBet, this);
        
         this._initFichesBut();
@@ -235,20 +235,20 @@ function CInterface(){
     
     this._initFichesBut = function(){
         var oFicheBg = createBitmap(s_oSpriteLibrary.getSprite('chip_box'));
-        oFicheBg.x = 50;  // Movido mais para a esquerda para dar espaço
-        oFicheBg.y = 120; // Movido um pouco para baixo
+        oFicheBg.x = 50;   // Posicionado na lateral esquerda
+        oFicheBg.y = 300;  // Meio da tela verticalmente
         s_oStage.addChild(oFicheBg);
         
-        //SET FICHES BUTTON
-        var iCurX = 92;   // Ajustado conforme nova posição
-        var iCurY = 170;  // Ajustado conforme nova posição
+        //SET FICHES BUTTON - DISPOSTAS HORIZONTALMENTE PARA ECONOMIZAR ESPAÇO
+        var iCurX = 60;    // Começa na lateral esquerda
+        var iCurY = 350;   // Altura média
         _aFiches = new Array();
         for(var i=0;i<NUM_FICHES;i++){
             var oSprite = s_oSpriteLibrary.getSprite('fiche_'+i);
             _aFiches[i] = new CFicheBut(iCurX,iCurY,oSprite);
             _aFiches[i].addEventListenerWithParams(ON_MOUSE_UP, this._onFicheSelected, this,[i]);
             
-            iCurY += oSprite.height + 25;
+            iCurY += oSprite.height + 15;  // Espaçamento ainda mais reduzido
         }
     };
     

--- a/game/js/CTableController.js
+++ b/game/js/CTableController.js
@@ -26,22 +26,22 @@ function CTableController(){
         var oBmp;
         _aEnlights = new Array();
         
-        oBmp = new CEnlight(175,162,s_oSpriteLibrary.getSprite('enlight_pass_line'),_oContainer);
+        oBmp = new CEnlight(200,180,s_oSpriteLibrary.getSprite('enlight_pass_line'),_oContainer);  // Ajustado
         _aEnlights["pass_line"] = oBmp;
         
-        oBmp = new CEnlight(365,476,s_oSpriteLibrary.getSprite('enlight_dont_pass1'),_oContainer);
+        oBmp = new CEnlight(380,450,s_oSpriteLibrary.getSprite('enlight_dont_pass1'),_oContainer);  // Ajustado
         _aEnlights["dont_pass1"] = oBmp;
         
-        oBmp = new CEnlight(227,127,s_oSpriteLibrary.getSprite('enlight_dont_pass2'),_oContainer);
+        oBmp = new CEnlight(250,140,s_oSpriteLibrary.getSprite('enlight_dont_pass2'),_oContainer);  // Ajustado
         _aEnlights["dont_pass2"] = oBmp;    
         
-        oBmp = new CEnlight(279,127,s_oSpriteLibrary.getSprite('enlight_dont_come'),_oContainer);
+        oBmp = new CEnlight(300,140,s_oSpriteLibrary.getSprite('enlight_dont_come'),_oContainer);  // Ajustado
         _aEnlights["dont_come"] = oBmp; 
         
-        oBmp = new CEnlight(279,264,s_oSpriteLibrary.getSprite('enlight_come'),_oContainer);
+        oBmp = new CEnlight(300,280,s_oSpriteLibrary.getSprite('enlight_come'),_oContainer);  // Ajustado
         _aEnlights["come"] = oBmp; 
         
-        var aPos = [{value:4,x:365,y:127},{value:5,x:451,y:127},{value:6,x:537,y:127},{value:8,x:623,y:127},{value:9,x:709,y:127},{value:10,x:795,y:127}];
+        var aPos = [{value:4,x:380,y:140},{value:5,x:460,y:140},{value:6,x:540,y:140},{value:8,x:620,y:140},{value:9,x:700,y:140},{value:10,x:780,y:140}];  // Posições mais compactas
         for(var i=0;i<6;i++){
             oBmp = new CEnlight(aPos[i].x,aPos[i].y,s_oSpriteLibrary.getSprite('enlight_lay_bet'),_oContainer);
             _aEnlights["lay_bet"+aPos[i].value] = oBmp;
@@ -56,20 +56,20 @@ function CTableController(){
             _aEnlights["win_bet"+aPos[i].value] = oBmp;
         }
         
-        oBmp = new CEnlight(226,391,s_oSpriteLibrary.getSprite('enlight_big_6'),_oContainer);
+        oBmp = new CEnlight(240,380,s_oSpriteLibrary.getSprite('enlight_big_6'),_oContainer);  // Ajustado
         _aEnlights["big_6"] = oBmp; 
         
-        oBmp = new CEnlight(240,434,s_oSpriteLibrary.getSprite('enlight_big_8'),_oContainer);
+        oBmp = new CEnlight(260,420,s_oSpriteLibrary.getSprite('enlight_big_8'),_oContainer);  // Ajustado
         _aEnlights["big_8"] = oBmp; 
         
-        oBmp = new CEnlight(281,391,s_oSpriteLibrary.getSprite('enlight_field'),_oContainer);
+        oBmp = new CEnlight(300,380,s_oSpriteLibrary.getSprite('enlight_field'),_oContainer);  // Ajustado
         _aEnlights["field"] = oBmp; 
         
-        //ENLIGHT ANY 11
-        var iXAny11 = 806;
-        var iYAny11 = 401;
-        var iXAnyCraps = 840;
-        var iYAnyCraps = 409;
+        //ENLIGHT ANY 11 - MOVIDO MAIS PARA O CENTRO
+        var iXAny11 = 780;  // Movido mais para a esquerda
+        var iYAny11 = 380;  // Movido um pouco para cima
+        var iXAnyCraps = 810;  // Movido mais para a esquerda
+        var iYAnyCraps = 390;  // Movido um pouco para cima
         for(var i=0;i<7;i++){
             oBmp = new CEnlight(iXAny11,iYAny11,s_oSpriteLibrary.getSprite('enlight_circle'),_oContainer);
             _aEnlights["any11_"+i] = oBmp;
@@ -81,38 +81,38 @@ function CTableController(){
             iYAnyCraps += 34;
         }
         
-        oBmp = new CEnlight(877,551,s_oSpriteLibrary.getSprite('enlight_any11'),_oContainer);
+        oBmp = new CEnlight(850,520,s_oSpriteLibrary.getSprite('enlight_any11'),_oContainer);  // Movido para cima
         _aEnlights["any11_"+i] = oBmp; 
 
         //ENLIGHT ANY CRAPS
-        oBmp = new CEnlight(877,612,s_oSpriteLibrary.getSprite('enlight_any_craps'),_oContainer);
+        oBmp = new CEnlight(850,580,s_oSpriteLibrary.getSprite('enlight_any_craps'),_oContainer);  // Movido para cima
         _aEnlights["any_craps_"+i] = oBmp;
         
-        //ENLIGHT HARDWAYS
-        oBmp = new CEnlight(877,371,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);
+        //ENLIGHT HARDWAYS - MOVIDO MAIS PARA O CENTRO
+        oBmp = new CEnlight(850,340,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);  // Movido
         _aEnlights["hardway6"] = oBmp; 
         
-        oBmp = new CEnlight(1032,371,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);
+        oBmp = new CEnlight(980,340,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);  // Movido
         _aEnlights["hardway10"] = oBmp;
         
-        oBmp = new CEnlight(877,431,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);
+        oBmp = new CEnlight(850,400,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);  // Movido
         _aEnlights["hardway8"] = oBmp;
         
-        oBmp = new CEnlight(1032,431,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);
+        oBmp = new CEnlight(980,400,s_oSpriteLibrary.getSprite('enlight_proposition1'),_oContainer);  // Movido
         _aEnlights["hardway4"] = oBmp;
         
-        //ENLIGHT PROPOSITION 2
-        oBmp = new CEnlight(877,491,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);
+        //ENLIGHT PROPOSITION 2 - MOVIDO MAIS PARA O CENTRO
+        oBmp = new CEnlight(850,460,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);  // Movido
         _aEnlights["horn3"] = oBmp;
         
-        oBmp = new CEnlight(980,491,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);
+        oBmp = new CEnlight(915,460,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);  // Movido
         _aEnlights["horn2"] = oBmp;
         
-        oBmp = new CEnlight(1083,491,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);
+        oBmp = new CEnlight(980,460,s_oSpriteLibrary.getSprite('enlight_proposition2'),_oContainer);  // Movido
         _aEnlights["horn12"] = oBmp;
         
-        //ENLIGHT SEVEN BET
-        oBmp = new CEnlight(877,338,s_oSpriteLibrary.getSprite('enlight_seven'),_oContainer);
+        //ENLIGHT SEVEN BET - MOVIDO MAIS PARA O CENTRO
+        oBmp = new CEnlight(850,300,s_oSpriteLibrary.getSprite('enlight_seven'),_oContainer);  // Movido
         _aEnlights["seven_bet"] = oBmp; 
         
     };
@@ -123,8 +123,8 @@ function CTableController(){
         
         var oBut;
         
-        // Criar único botão "APOSTE AQUI" centralizado
-        var oMainBetButton = new CTextButton(640, 450, s_oSpriteLibrary.getSprite('but_bg'), "APOSTE AQUI", FONT1, "#fff", 18, "center", _oContainer);
+        // Criar único botão "APOSTE AQUI" melhor posicionado
+        var oMainBetButton = new CTextButton(500, 350, s_oSpriteLibrary.getSprite('but_bg'), "APOSTE AQUI", FONT1, "#fff", 18, "center", _oContainer);  // Posicionado no centro da mesa
         oMainBetButton.addEventListener(ON_MOUSE_UP, this._onMainBetClick.bind(this), this);
         oMainBetButton.addEventListener(ON_MOUSE_OVER, this._onBetNumberOver.bind(this, {button: "main_bet"}), this);
         oMainBetButton.addEventListener(ON_MOUSE_OUT, this._onBetNumberOut.bind(this, {button: "main_bet"}), this);


### PR DESCRIPTION
Reorganize the craps table layout to improve compactness and reduce empty spaces.

The previous layout had large empty areas and dispersed elements, making important information distant. This PR adjusts the positioning of UI elements, betting areas, and dice animations to create a denser, more intuitive, and visually occupied table.

---
<a href="https://cursor.com/background-agent?bcId=bc-36b094ca-d722-4705-bf61-6b2c41252089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36b094ca-d722-4705-bf61-6b2c41252089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

