### PR TITLE
Arrange buttons according to design

### DIFF
--- a/game/js/CFichesController.js
+++ b/game/js/CFichesController.js
@@ -72,9 +72,9 @@ function CFichesController(oContainer){
         this._removeFichesPile(_aMcFichesInPos[szNameAttach]);
         _aMcFichesInPos[szNameAttach] = new Array();
 
-        // Posição específica para o botão "APOSTE AQUI" (640, 450)
-        var iXPos = 640; // Posição X do botão
-        var iYPos = 450; // Posição Y do botão
+        // Posição específica para o botão "APOSTE AQUI" (alinhado ao botão visível)
+        var iXPos = 650; // Posição X do botão
+        var iYPos = 460; // Posição Y do botão
         for(var k=0;k<aFiches.length;k++){
                 aMcFiches.push(this._attachFichesPile(aFiches[k],szNameAttach,iXPos,iYPos));
                 iYPos-=5;

--- a/game/js/CInterface.js
+++ b/game/js/CInterface.js
@@ -26,8 +26,8 @@ function CInterface(){
     this._init = function(){
         
         var oMoneyBg = createBitmap(s_oSpriteLibrary.getSprite('but_bg'));
-        oMoneyBg.x = 251;
-        oMoneyBg.y = 603;
+        oMoneyBg.x = 310; // bloco "DINHEIRO" mais à esquerda
+        oMoneyBg.y = 610;
         s_oStage.addChild(oMoneyBg);
         
         var oMoneyText = new CTLText(s_oStage, 
@@ -41,7 +41,7 @@ function CInterface(){
 
         
         _oMoneyAmountText = new CTLText(s_oStage, 
-                    260, 636, 140, 16, 
+                    319, 643, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     " ",
@@ -50,8 +50,8 @@ function CInterface(){
 
         
         var oCurBetBg = createBitmap(s_oSpriteLibrary.getSprite('but_bg'));
-        oCurBetBg.x = 410;
-        oCurBetBg.y = 603;
+        oCurBetBg.x = 510; // "APOSTA ATUAL" centralizado no rodapé
+        oCurBetBg.y = 610;
         s_oStage.addChild(oCurBetBg);
         
         var oCurBetText = new CTLText(s_oStage, 
@@ -64,7 +64,7 @@ function CInterface(){
                     
         
         _oBetAmountText = new CTLText(s_oStage, 
-                    419, 636, 140, 16, 
+                    519, 643, 140, 16, 
                     16, "center", "#fff", FONT1, 1,
                     0, 0,
                     " ",
@@ -74,8 +74,8 @@ function CInterface(){
 
         
         _oDisplayBg = createBitmap(s_oSpriteLibrary.getSprite('but_bets'));
-        _oDisplayBg.x = 575;
-        _oDisplayBg.y = 610;
+        _oDisplayBg.x = 710; // "APOSTA MIN/MAX" mais à direita
+        _oDisplayBg.y = 617;
         s_oStage.addChild(_oDisplayBg);
 
         _oMsgTitle = new CTLText(s_oStage, 
@@ -118,11 +118,11 @@ function CInterface(){
         
         _szLastMsgHelp = TEXT_WAITING_BET;
 
-        _oRollBut = new CTextButton(1030,162,s_oSpriteLibrary.getSprite('roll_but'),"  "+TEXT_ROLL,FONT1,"#fff",22,"right",s_oStage);
+        _oRollBut = new CTextButton(1040,150,s_oSpriteLibrary.getSprite('roll_but'),"  "+TEXT_ROLL,FONT1,"#fff",22,"right",s_oStage);
         _oRollBut.disable();
         _oRollBut.addEventListener(ON_MOUSE_UP, this._onRoll, this);
       
-        _oClearAllBet = new CGfxButton(764,636,s_oSpriteLibrary.getSprite('but_clear_all'),s_oStage);
+        _oClearAllBet = new CGfxButton(930,642,s_oSpriteLibrary.getSprite('but_clear_all'),s_oStage);
         _oClearAllBet.addEventListener(ON_MOUSE_UP, this._onClearAllBet, this);
        
         this._initFichesBut();

--- a/game/js/CTableController.js
+++ b/game/js/CTableController.js
@@ -124,7 +124,7 @@ function CTableController(){
         var oBut;
         
         // Criar único botão "APOSTE AQUI" centralizado
-        var oMainBetButton = new CTextButton(640, 450, s_oSpriteLibrary.getSprite('but_bg'), "APOSTE AQUI", FONT1, "#fff", 18, "center", _oContainer);
+        var oMainBetButton = new CTextButton(650, 460, s_oSpriteLibrary.getSprite('but_bg'), "APOSTE AQUI", FONT1, "#fff", 18, "center", _oContainer);
         oMainBetButton.addEventListener(ON_MOUSE_UP, this._onMainBetClick.bind(this), this);
         oMainBetButton.addEventListener(ON_MOUSE_OVER, this._onBetNumberOver.bind(this, {button: "main_bet"}), this);
         oMainBetButton.addEventListener(ON_MOUSE_OUT, this._onBetNumberOut.bind(this, {button: "main_bet"}), this);


### PR DESCRIPTION
Repositioned "APOSTE AQUI" button, chip drop, and footer info blocks to match the user's requested layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d914c4f-269d-4b91-b7bb-898389e6cab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d914c4f-269d-4b91-b7bb-898389e6cab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

