### PR TITLE
Adjust room selection position for desktop

### DIFF
--- a/game/js/CInterface.js
+++ b/game/js/CInterface.js
@@ -106,7 +106,7 @@ function CInterface(){
                     false );
 
         // Botões de seleção de sala - posição ajustada para mobile
-        var iRoomButtonX = s_bMobile ? 20 : 220;
+        var iRoomButtonX = s_bMobile ? 120 : 220;
         _oButRoomBronze = new CTextButton(iRoomButtonX, 40, s_oSpriteLibrary.getSprite('but_bg'), "BRONZE", FONT1, "#fff", 16, "center", s_oStage);
         _oButRoomBronze.addEventListener(ON_MOUSE_UP, function(){ s_oGame.changeRoom("bronze"); }, this);
         _oButRoomPrata = new CTextButton(iRoomButtonX, 85, s_oSpriteLibrary.getSprite('but_bg'), "PRATA", FONT1, "#fff", 16, "center", s_oStage);
@@ -221,10 +221,10 @@ function CInterface(){
         
         // Correção para botões de sala no mobile - manter posição fixa
         if(s_bMobile){
-            // No mobile, manter posição fixa para garantir visibilidade
-            if (_oButRoomBronze) { _oButRoomBronze.setPosition(20, 40 + iNewY); }
-            if (_oButRoomPrata) { _oButRoomPrata.setPosition(20, 85 + iNewY); }
-            if (_oButRoomOuro) { _oButRoomOuro.setPosition(20, 130 + iNewY); }
+            // No mobile, manter posição fixa mais à direita
+            if (_oButRoomBronze) { _oButRoomBronze.setPosition(120, 40 + iNewY); }
+            if (_oButRoomPrata) { _oButRoomPrata.setPosition(120, 85 + iNewY); }
+            if (_oButRoomOuro) { _oButRoomOuro.setPosition(120, 130 + iNewY); }
         } else {
             // No desktop, aplicar offset normal
             if (_oButRoomBronze) { _oButRoomBronze.setPosition(220 - iNewX, 40 + iNewY); }


### PR DESCRIPTION
Move room selection buttons to the right on mobile devices.

The room selection buttons were positioned too far to the left on mobile screens, making them less accessible. This PR adjusts their X-coordinate from 20 to 120 pixels on mobile to improve their positioning and visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9301a0-23d3-4bc7-9de4-986f7c2f59bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f9301a0-23d3-4bc7-9de4-986f7c2f59bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

