### PR TITLE
Fix unique constraint syntax error

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -71,9 +71,7 @@ CREATE TABLE IF NOT EXISTS public.player_sessions (
     left_at TIMESTAMP WITH TIME ZONE,
     is_active BOOLEAN DEFAULT true,
     player_order INTEGER, -- Turn order in the room
-    socket_id TEXT, -- For real-time tracking
-    -- Prevent duplicate active sessions
-    UNIQUE(player_id, room_id) WHERE is_active = true
+    socket_id TEXT -- For real-time tracking
 );
 
 -- ==============================================
@@ -130,6 +128,11 @@ CREATE INDEX IF NOT EXISTS idx_game_sessions_status ON public.game_sessions(stat
 CREATE INDEX IF NOT EXISTS idx_game_bets_active ON public.game_bets(game_session_id, status);
 CREATE INDEX IF NOT EXISTS idx_dice_rolls_session ON public.dice_rolls(game_session_id, rolled_at);
 CREATE INDEX IF NOT EXISTS idx_game_events_room ON public.game_events(room_id, created_at);
+
+-- Prevent duplicate active sessions (partial unique index)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_player_sessions_unique_active 
+ON public.player_sessions(player_id, room_id) 
+WHERE is_active = true;
 
 -- ==============================================
 -- ROW LEVEL SECURITY (RLS) POLICIES


### PR DESCRIPTION
Fix PostgreSQL syntax error for partial unique constraint by converting it to a separate unique index.

The original inline `UNIQUE(player_id, room_id) WHERE is_active = true` constraint was syntactically invalid in PostgreSQL. This PR replaces it with a `CREATE UNIQUE INDEX ... WHERE is_active = true` statement, which is the correct way to define a partial unique constraint in PostgreSQL, maintaining the original intent of preventing duplicate active player sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e71f2759-bc5a-42b5-9e91-e07e3bb91a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e71f2759-bc5a-42b5-9e91-e07e3bb91a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

