### PR TITLE
Resolve ambiguous room_name reference

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -241,7 +241,7 @@ BEGIN
             
             INSERT INTO public.game_rooms (room_type, room_name, min_bet, max_bet, max_players)
             VALUES (room_configs.room_type, room_name, room_configs.min_bet, room_configs.max_bet, 8)
-            ON CONFLICT (room_type, room_name) DO NOTHING;
+            ON CONFLICT (public.game_rooms.room_type, public.game_rooms.room_name) DO NOTHING;
         END LOOP;
     END LOOP;
 END;


### PR DESCRIPTION
Qualify column names in `ON CONFLICT` clause to resolve ambiguous reference error.

The `create_room_instances()` function encountered an `ERROR: 42702: column reference "room_name" is ambiguous` because a PL/pgSQL variable and a table column shared the same name. Explicitly qualifying the column names in the `ON CONFLICT` clause (`public.game_rooms.room_type, public.game_rooms.room_name`) resolves this ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9194c3-bd86-47b3-bdfc-e546bc4be108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f9194c3-bd86-47b3-bdfc-e546bc4be108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

