### PR TITLE
Fix sql on conflict syntax error

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -241,7 +241,7 @@ BEGIN
             
             INSERT INTO public.game_rooms (room_type, room_name, min_bet, max_bet, max_players)
             VALUES (room_configs.room_type, room_name, room_configs.min_bet, room_configs.max_bet, 8)
-            ON CONFLICT (public.game_rooms.room_type, public.game_rooms.room_name) DO NOTHING;
+            ON CONFLICT (room_type, room_name) DO NOTHING;
         END LOOP;
     END LOOP;
 END;


### PR DESCRIPTION
Fix SQL syntax error in `ON CONFLICT` clause by removing table qualification from column names.

The `ON CONFLICT` clause in PostgreSQL should reference unqualified column names when targeting a unique constraint, rather than table-qualified names like `public.game_rooms.room_type`. This change corrects the syntax to `ON CONFLICT (room_type, room_name)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb81d7f7-29b1-4a82-a86c-ce7ffa34e5b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb81d7f7-29b1-4a82-a86c-ce7ffa34e5b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

