### PR TITLE
Resolve ambiguous room_name reference

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -240,7 +240,7 @@ BEGIN
             room_name := UPPER(room_configs.room_type) || '-' || LPAD(room_counter::TEXT, 3, '0');
             
             INSERT INTO public.game_rooms (room_type, room_name, min_bet, max_bet, max_players)
-            VALUES (room_configs.room_type, room_name, room_configs.min_bet, room_configs.max_bet, 8)
+            VALUES (room_configs.room_type, create_room_instances.room_name, room_configs.min_bet, room_configs.max_bet, 8)
             ON CONFLICT (room_type, room_name) DO NOTHING;
         END LOOP;
     END LOOP;


### PR DESCRIPTION
Qualify `room_name` variable in `create_room_instances` function to resolve an ambiguous column reference error.

The `room_name` identifier was ambiguous in the `INSERT` statement, referring to both a local PL/pgSQL variable and a table column. Qualifying the variable with the function name (`create_room_instances.room_name`) explicitly tells PostgreSQL to use the local variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaaf5853-accd-4d05-97e0-010ed6387108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaaf5853-accd-4d05-97e0-010ed6387108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

