### PR TITLE
Fix missing from-clause for room creation

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -240,7 +240,7 @@ BEGIN
             room_name := UPPER(room_configs.room_type) || '-' || LPAD(room_counter::TEXT, 3, '0');
             
             INSERT INTO public.game_rooms (room_type, room_name, min_bet, max_bet, max_players)
-            VALUES (room_configs.room_type, create_room_instances.room_name, room_configs.min_bet, room_configs.max_bet, 8)
+            VALUES (room_configs.room_type, room_name, room_configs.min_bet, room_configs.max_bet, 8)
             ON CONFLICT (room_type, room_name) DO NOTHING;
         END LOOP;
     END LOOP;


### PR DESCRIPTION
Correct `create_room_instances` function to reference the local `room_name` variable instead of the function name.

The previous `INSERT` statement incorrectly used `create_room_instances.room_name`, which PostgreSQL interpreted as a table reference, leading to a "missing FROM-clause entry" error. This change ensures the correct local variable is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cb4bb22-e366-44fb-96ff-108935c3de9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cb4bb22-e366-44fb-96ff-108935c3de9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

