### PR TITLE
Investigate Supabase room join errors

### DIFF
--- a/game/js/realtime.js
+++ b/game/js/realtime.js
@@ -120,7 +120,22 @@ window.Realtime = (function(){
                 }
             }).catch(function(error) {
                 console.error('Failed to join Supabase room:', error);
-                alert('Erro ao entrar na sala: ' + (error.message || 'Erro desconhecido'));
+                
+                // Provide more specific error messages
+                let errorMessage = 'Erro desconhecido';
+                if (error.message) {
+                    if (error.message.includes('session conflict') || error.message.includes('duplicate')) {
+                        errorMessage = 'Conflito de sessão detectado. Tente novamente em alguns segundos.';
+                    } else if (error.message.includes('No available rooms')) {
+                        errorMessage = 'Não há salas disponíveis deste tipo no momento.';
+                    } else if (error.message.includes('not authenticated')) {
+                        errorMessage = 'Você precisa fazer login para entrar em uma sala.';
+                    } else {
+                        errorMessage = error.message;
+                    }
+                }
+                
+                alert('Erro ao entrar na sala: ' + errorMessage);
             });
         } else {
             // Fallback to Socket.io

--- a/game/js/supabase-multiplayer.js
+++ b/game/js/supabase-multiplayer.js
@@ -76,6 +76,23 @@ window.SupabaseMultiplayer = (function(){
 
             if (error) {
                 console.error('Error joining room:', error);
+                
+                // Handle specific error cases
+                if (error.code === '23505' || error.message?.includes('duplicate') || error.message?.includes('unique')) {
+                    console.warn('Duplicate session detected, attempting to resolve...');
+                    // Try to leave current room and rejoin
+                    try {
+                        await leaveRoom();
+                        // Wait a moment for cleanup
+                        await new Promise(resolve => setTimeout(resolve, 500));
+                        // Retry the join
+                        return await joinRoom(roomType, socketId);
+                    } catch (retryError) {
+                        console.error('Failed to resolve duplicate session:', retryError);
+                        throw new Error('Unable to join room due to session conflict. Please refresh the page.');
+                    }
+                }
+                
                 throw error;
             }
 


### PR DESCRIPTION
Fix 409 conflict errors when joining a Supabase room by making the `join_room` function idempotent and adding client-side retry logic.

The 409 errors stemmed from a unique constraint violation (`idx_player_sessions_unique_active`) in the `player_sessions` table when a player attempted to join a room where they already had an active session. The database function now checks for an existing active session before inserting, updating the existing session if found, and only incrementing player count and logging a join event for genuinely new joins. Client-side code now attempts to resolve duplicate session conflicts by retrying the join after a brief delay, and user-facing error messages are more informative.

---
<a href="https://cursor.com/background-agent?bcId=bc-8323fa3f-ebe1-4b42-81c0-2bde1aa96f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8323fa3f-ebe1-4b42-81c0-2bde1aa96f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

