### PR TITLE
Fix realtime subscribe error in join room

### DIFF
--- a/game/js/supabase-realtime-dice.js
+++ b/game/js/supabase-realtime-dice.js
@@ -83,18 +83,15 @@ window.SupabaseRealtimeDice = (function() {
         realtimeChannel.on('presence', { event: 'join' }, handlePresenceJoin);
         realtimeChannel.on('presence', { event: 'leave' }, handlePresenceLeave);
 
-        // Subscribe to the channel
-        return realtimeChannel.subscribe().then(function(status) {
-            if (status === 'SUBSCRIBED') {
-                isSubscribed = true;
-                console.log('Successfully subscribed to room:', roomId);
-                
-                // Join the room session and turn cycle
-                return joinRoomSession(roomId);
-            } else {
-                throw new Error('Failed to subscribe to realtime channel');
-            }
-        });
+        // Subscribe to the channel (synchronous in Supabase v2)
+        realtimeChannel.subscribe();
+        
+        // Set subscription status
+        isSubscribed = true;
+        console.log('Subscribed to realtime channel for room:', roomId);
+        
+        // Join the room session and turn cycle
+        return joinRoomSession(roomId);
     }
 
     function joinRoomSession(roomId) {


### PR DESCRIPTION
Remove `.then()` chain from `realtimeChannel.subscribe()` because it is synchronous in Supabase v2 and does not return a Promise.

---
<a href="https://cursor.com/background-agent?bcId=bc-e75bfe0c-1936-46d7-abcc-8312a9200ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e75bfe0c-1936-46d7-abcc-8312a9200ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

